### PR TITLE
fixed entrypoint, which does not find /var/www/html/artisan.

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,3 +1,4 @@
+COMPOSE_PROJECT_NAME=laravel
 MYSQL_ROOT_PWD=root_passwd
 MYSQL_DB_NAME=bd_name
 MYSQL_USER_ID=user_id

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,7 @@ services:
     depends_on: # dependency 필요 
       - mysql
     working_dir: /var/www/html
-    entrypoint: ['/var/www/html/artisan']  
+    entrypoint: ['php', '/var/www/html/artisan'] # Added 'php' before '/var/www/html/artisan'
     networks: 
       - laravel
     # docker-compose run --rm artisan migrate 로 하면 된다!


### PR DESCRIPTION
COMPOSE_PROJECT_NAME added in .env-example.
this is equivalent to 'docker compose -p 'projectname'  up'